### PR TITLE
fix demo.py with --device cpu and no CUDA device available

### DIFF
--- a/third_party/raft.py
+++ b/third_party/raft.py
@@ -60,7 +60,10 @@ def load_RAFT(model_path=None):
         args = parse_args(parser)
         net = RAFT2(args)
 
-    state_dict = torch.load(args.model)
+    if torch.cuda.is_available():
+        state_dict = torch.load(args.model)
+    else:
+        state_dict = torch.load(args.model, map_location="cpu")
     print('Loaded pretrained RAFT model from', args.model)
     new_state_dict = {}
     for k in state_dict:

--- a/third_party/sam2/sam2/sam2_video_predictor.py
+++ b/third_party/sam2/sam2/sam2_video_predictor.py
@@ -953,7 +953,8 @@ class SAM2VideoPredictor(SAM2Base):
         storage_device = inference_state["storage_device"]
         maskmem_features = current_out["maskmem_features"]
         if maskmem_features is not None:
-            maskmem_features = maskmem_features.to(torch.bfloat16)
+            if torch.cuda.is_available():
+                maskmem_features = maskmem_features.to(torch.bfloat16)
             maskmem_features = maskmem_features.to(storage_device, non_blocking=True)
         pred_masks_gpu = current_out["pred_masks"]
         # potentially fill holes in the predicted masks
@@ -1005,7 +1006,8 @@ class SAM2VideoPredictor(SAM2Base):
 
         # optionally offload the output to CPU memory to save GPU space
         storage_device = inference_state["storage_device"]
-        maskmem_features = maskmem_features.to(torch.bfloat16)
+        if torch.cuda.is_available():
+            maskmem_features = maskmem_features.to(torch.bfloat16)
         maskmem_features = maskmem_features.to(storage_device, non_blocking=True)
         # "maskmem_pos_enc" is the same across frames, so we only need to store one copy of it
         maskmem_pos_enc = self._get_maskmem_pos_enc(


### PR DESCRIPTION
Hi, I've been trying to run inference on CPU to get around large VRAM requirements:

```bash
CUDA_VISIBLE_DEVICES="" python demo.py --device cpu --input demo_data/lady-running --output_dir demo_tmp --seq_name lady-running
```

However, out-of-the-box this didn't work, a few lines of code needed to be added. Now it works both with and without CUDA.